### PR TITLE
job application API endpoints

### DIFF
--- a/server/internal/controller/job_application_controller.go
+++ b/server/internal/controller/job_application_controller.go
@@ -1,5 +1,16 @@
 package controller
 
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lnwdevelopers007/job-applier-3000/server/internal/database"
+	"github.com/lnwdevelopers007/job-applier-3000/server/internal/schema"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 // JobApplicationController handles JobApplication CRUD operations
 type JobApplicationController struct {
@@ -11,3 +22,54 @@ func NewJobApplicationController() JobApplicationController {
 	return JobApplicationController{collectionName: "job_applications"}
 }
 
+// QueryApplications supports querying applications with optional filters
+func (jc JobApplicationController) QueryApplications() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        db := database.GetDatabase()
+        collection := db.Collection(jc.collectionName)
+
+        // Filters from query params
+        applicantID := c.Query("applicantID")
+        jobID := c.Query("jobID")
+        companyID := c.Query("companyID")
+        status := c.Query("status")
+
+        filter := bson.M{}
+
+        if applicantID != "" {
+            if objID, err := primitive.ObjectIDFromHex(applicantID); err == nil {
+                filter["applicantID"] = objID
+            }
+        }
+        if jobID != "" {
+            if objID, err := primitive.ObjectIDFromHex(jobID); err == nil {
+                filter["jobID"] = objID
+            }
+        }
+        if companyID != "" {
+            if objID, err := primitive.ObjectIDFromHex(companyID); err == nil {
+                filter["companyID"] = objID
+            }
+        }
+        if status != "" {
+            filter["status"] = status
+        }
+
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
+        cursor, err := collection.Find(ctx, filter)
+        if err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+            return
+        }
+
+        var applications []schema.JobApplication
+        if err := cursor.All(ctx, &applications); err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+            return
+        }
+
+        c.JSON(http.StatusOK, applications)
+    }
+}

--- a/server/internal/controller/job_application_controller.go
+++ b/server/internal/controller/job_application_controller.go
@@ -140,3 +140,31 @@ func (jc JobApplicationController) UpdateApplication() gin.HandlerFunc {
         c.JSON(http.StatusOK, gin.H{"message": "Application updated successfully"})
     }
 }
+
+// DeleteApplication deletes a job application by ID
+func (jc JobApplicationController) DeleteApplication() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        id := c.Param("id")
+        objID, err := primitive.ObjectIDFromHex(id)
+        if err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID format"})
+            return
+        }
+
+        db := database.GetDatabase()
+        collection := db.Collection(jc.collectionName)
+
+        res, err := collection.DeleteOne(context.Background(), bson.M{"_id": objID})
+        if err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+            return
+        }
+
+        if res.DeletedCount == 0 {
+            c.JSON(http.StatusNotFound, gin.H{"error": "Application not found"})
+            return
+        }
+
+        c.JSON(http.StatusOK, gin.H{"message": "Application deleted successfully"})
+    }
+}

--- a/server/internal/controller/job_application_controller.go
+++ b/server/internal/controller/job_application_controller.go
@@ -1,0 +1,13 @@
+package controller
+
+
+// JobApplicationController handles JobApplication CRUD operations
+type JobApplicationController struct {
+	collectionName string
+}
+
+// NewJobApplicationController initializes a JobApplicationController
+func NewJobApplicationController() JobApplicationController {
+	return JobApplicationController{collectionName: "job_applications"}
+}
+

--- a/server/internal/controller/router.go
+++ b/server/internal/controller/router.go
@@ -38,6 +38,13 @@ func NewRouter() *gin.Engine {
 
 	}
 
+	applicationController := NewJobApplicationController()
+	applyRoutes := router.Group("/apply")
+	{
+		applyRoutes.GET("/query", applicationController.QueryApplications())
+	
+	}
+
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"ok": true})
 	})

--- a/server/internal/controller/router.go
+++ b/server/internal/controller/router.go
@@ -43,6 +43,7 @@ func NewRouter() *gin.Engine {
 	{
 		applyRoutes.GET("/query", applicationController.QueryApplications())
 		applyRoutes.POST("/", applicationController.CreateApplication())
+		applyRoutes.PUT("/:id", applicationController.UpdateApplication())
 	
 	}
 

--- a/server/internal/controller/router.go
+++ b/server/internal/controller/router.go
@@ -42,6 +42,7 @@ func NewRouter() *gin.Engine {
 	applyRoutes := router.Group("/apply")
 	{
 		applyRoutes.GET("/query", applicationController.QueryApplications())
+		applyRoutes.POST("/", applicationController.CreateApplication())
 	
 	}
 

--- a/server/internal/controller/router.go
+++ b/server/internal/controller/router.go
@@ -44,7 +44,7 @@ func NewRouter() *gin.Engine {
 		applyRoutes.GET("/query", applicationController.QueryApplications())
 		applyRoutes.POST("/", applicationController.CreateApplication())
 		applyRoutes.PUT("/:id", applicationController.UpdateApplication())
-	
+		applyRoutes.DELETE("/:id", applicationController.DeleteApplication())
 	}
 
 	router.GET("/health", func(c *gin.Context) {

--- a/server/internal/schema/job_application.go
+++ b/server/internal/schema/job_application.go
@@ -12,5 +12,5 @@ type JobApplication struct {
 	JobID       primitive.ObjectID `bson:"jobID" json:"jobID" binding:"required"`
 	CompanyID   primitive.ObjectID `bson:"companyID" json:"companyID" binding:"required"`
 	Status      string             `bson:"status" json:"status" binding:"required"`
-	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt" binding:"required"`
+	CreatedAt   time.Time          `bson:"createdAt" json:"createdAt"`
 }


### PR DESCRIPTION
### Description (What have you done?)

- describe your changes in detail.
    - Added GET /apply/query endpoint to query job applications with optional filters
    - Implemented POST /apply endpoint to create a new job application (server sets CreatedAt)
    - Implemented PUT /apply/:id endpoint to update an existing job application by ID
    - Implemented DELETE /apply/:id endpoint to delete a job application by ID

- Expected behaviour and acceptance criteria of work in this pull request.
    - Users can list job applications using /apply/query
    - Users can create new job applications via /apply
    - Users can update an existing job application by ID via /apply/:id
    - Users can delete a job application by ID via /apply/:id

API responds with correct status codes and messages for success/error cases
### Checklist

- [ ] Code review
- [ ] Tests have been added
- [ ] Documentation
- [ ] Code guidelines

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

### Additional Information

- This PR completes the Job Application feature, providing full CRUD support. 
- Future improvements may include authentication, pagination for queries, and advanced filters.
