### PR TITLE
Add JobSeeker Endpoint and revise JobApp

### DIFF
--- a/server/internal/controller/job_seeker_controller.go
+++ b/server/internal/controller/job_seeker_controller.go
@@ -18,6 +18,10 @@ func NewJobSeekerController() JobSeekerController {
 	}
 }
 
+func (jc JobSeekerController) RetrieveAll(c *gin.Context) {
+	jc.baseController.RetrieveAll(c)
+}
+
 func (jc JobSeekerController) Create(c *gin.Context) {
 	jc.baseController.Create(c)
 }

--- a/server/internal/controller/router.go
+++ b/server/internal/controller/router.go
@@ -50,6 +50,7 @@ func NewRouter() *gin.Engine {
 	jobSeeker := NewJobSeekerController()
 	jobSeekerRoutes := router.Group("/seeker")
 	{
+		jobSeekerRoutes.GET("/", jobSeeker.RetrieveAll)
 		jobSeekerRoutes.POST("/", jobSeeker.Create)
 		jobSeekerRoutes.PUT("/", jobSeeker.Update)
 		jobSeekerRoutes.DELETE("/", jobSeeker.Delete)

--- a/server/internal/schema/job_seeker.go
+++ b/server/internal/schema/job_seeker.go
@@ -11,7 +11,7 @@ type JobSeeker struct {
 type ContactInfo struct {
 	Location string `bson:"location" json:"location" binding:"required"`
 	Phone    string `bson:"phone" json:"phone" binding:"required"`
-	LinkedIn string `bson:"linkedIn" json:"linkedIn" binding:"required"`
+	LinkedIn string `bson:"linkedIn" json:"linkedIn"`
 }
 
 type JobSeekerDenormalised struct {

--- a/server/internal/schema/job_seeker_test.go
+++ b/server/internal/schema/job_seeker_test.go
@@ -72,5 +72,5 @@ func TestJobSeekerMissingLinkedInInContact(t *testing.T) {
 	contact := payload["contact"].(map[string]any)
 	delete(contact, "linkedIn")
 	_, err := bindMockJobSeeker(t, payload)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
### Description (What have you done?)

- Add CRUD endpoints for JobSeeker data.
- Revise Job Application so that it returns the actual job seeker info instead of foreign key to the job seeker's collection. This is done after discussions with @Thanawas-Sirilertsathit , which he stated that he want to use job seeker's query endpoint for getting applicant's info when displaying all job applications to the company recruiter. So I suggest modifying Job Application endpoint instead because the client won't have to call the server multiple times to get that info.
- Therefore, from the previous point, I did not implement query for job seeker. If someone want this, pls flag change requested for this pr. 
- LinkedIn is no longer a required field since I had realised that not everyone have LinkedIn account.
- The new endpoint is in `/seeker`.

### Functional Acceptance Criteria (What is your expectation?)

- Can Create, Retrieve (all), Update and Delete Job Seekers
- Job Application Endpoints can return the actual user info.

### Checklist

- [ ] Code review
- [x] Tests have been added
- [ ] Documentation
- [ ] Code guidelines

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)

### Additional Information

- Actually MongoDB doesn't support `JOIN` statement found in most SQL databases so the code for joining job seeker together is kinda long and a bit spaghetti. I kinda regret picking this DBMS at this point.....